### PR TITLE
Updated README, code sample with semi-colons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,16 +361,16 @@ Heavily inspired by them as well:
     ```javascript
     // bad
     var i;
-    var items = getItems(),
-    var dragonball,
-    var goSportsTeam = true,
+    var items = getItems();
+    var dragonball;
+    var goSportsTeam = true;
     var len;
 
     // good
-    var items = getItems(),
-    var goSportsTeam = true,
-    var dragonball,
-    var length,
+    var items = getItems();
+    var goSportsTeam = true;
+    var dragonball;
+    var length;
     var i;
     ```
 


### PR DESCRIPTION
Code examples ended in commas instead of semi-colons.  Fixed as it's distracting to look through when it's trying to illustrate variable declaration order.
